### PR TITLE
Replaced deprecated resource

### DIFF
--- a/app/src/main/res/layout/fragment_share_exposure_start.xml
+++ b/app/src/main/res/layout/fragment_share_exposure_start.xml
@@ -105,7 +105,7 @@
           android:layout_height="wrap_content"
           android:hint="@string/test_date_label"
           android:importantForAutofill="no"
-          android:editable="false"
+          android:inputType="none"
           android:focusable="false"
           tools:ignore="TextFields" />
 


### PR DESCRIPTION
`android:editable` is deprecated. Replaced `android:inputType`.