### PR TITLE
Fixing importing ktx version of viewmodel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0-beta01'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.4'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.work:work-runtime:2.3.4'
     implementation 'androidx.multidex:multidex:2.0.1'


### PR DESCRIPTION
This module is not using Kotlin. should not be using -ktx version of the library

changing implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
to changing implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'