### PR TITLE
removing androidx.multidex:multidex

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,10 +80,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0-beta01'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.4'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.work:work-runtime:2.3.4'
-    implementation 'androidx.multidex:multidex:2.0.1'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test.ext:junit:1.1.2-beta01'

--- a/app/src/main/java/com/google/android/apps/exposurenotification/ExposureNotificationApplication.java
+++ b/app/src/main/java/com/google/android/apps/exposurenotification/ExposureNotificationApplication.java
@@ -17,7 +17,7 @@
 
 package com.google.android.apps.exposurenotification;
 
-import androidx.multidex.MultiDexApplication;
+import android.app.Application;
 import com.google.android.apps.exposurenotification.activities.ExposureNotificationActivity;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 
@@ -26,7 +26,7 @@ import com.jakewharton.threetenabp.AndroidThreeTen;
  *
  * <p>For UI see {@link ExposureNotificationActivity}
  */
-public final class ExposureNotificationApplication extends MultiDexApplication {
+public final class ExposureNotificationApplication extends Application {
 
   @Override
   public void onCreate() {


### PR DESCRIPTION
Removing androidx.multidex:multidex from gradle because it is enabled by default for SDK 21+

https://developer.android.com/studio/build/multidex#mdex-on-l
>Therefore, if your minSdkVersion is 21 or higher multidex is enabled by default, and you do not need the multidex support library.